### PR TITLE
Corrected install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,20 @@ injection container. It is particularly useful in functional tests.
 
 ## Installation
 
-Add SymfonyContainerMocks to your composer.json:
+Add SymfonyContainerMocks using composer:
+
+`composer require "ramunasd/symfony-container-mocks"`
+
+or edit your composer.json:
 
 ```js
 {
     "require": {
-        "ramuansd/symfony-container-mocks": "*"
+        "ramunasd/symfony-container-mocks": "*"
     }
 }
 ```
+
 
 Replace base container class for test environment in `app/AppKernel.php`
 


### PR DESCRIPTION
There was a typo in the example composer.json fragment, also added equivalent composer require command line
