### PR TITLE
make TestContainer::getProphet() public

### DIFF
--- a/src/DependencyInjection/TestContainer.php
+++ b/src/DependencyInjection/TestContainer.php
@@ -125,7 +125,7 @@ class TestContainer extends Container
     /**
      * @return Prophet
      */
-    protected function getProphet()
+    public function getProphet()
     {
         if (!$this->prophet) {
             $this->prophet = new Prophet();

--- a/tests/DependencyInjection/TestContainerTest.php
+++ b/tests/DependencyInjection/TestContainerTest.php
@@ -139,5 +139,11 @@ class TestContainerTest extends \PHPUnit_Framework_TestCase
         $this->container->prophesize($id, 'stdClass');
         $this->assertTrue($this->container->initialized($id));
     }
+
+    public function testGetProphecyReturnsSameObjectTwice()
+    {
+        $prophet = $this->container->getProphet();
+        $this->assertSame($prophet, $this->container->getProphet());
+    }
 }
 


### PR DESCRIPTION
To be able to call the checkPredictions() function in tearDown() we need
to be able to access the `TestContainer::$prophet` property.